### PR TITLE
flow 0.18.1

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -180,7 +180,7 @@ export function validateInstanceOf(func:Function):Validator {
 
 export function validateRegex(regex:RegExp):Validator {
   return function(val) {
-    return (regex.test(val)) || "did not match " + regex
+    return (regex.test(val)) || "did not match " + regex.toString()
   }
 }
 


### PR DESCRIPTION
The current version of runtime-types doesn't pass all of Flow's type checks.  This fixes the error.
