### PR TITLE
Update deps and unpin babel version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "esprima-fb": "15001.1.0-dev-harmony-fb",
-    "lodash": "3.9.3"
+    "esprima-fb": "15001.1001.0-dev-harmony-fb",
+    "lodash": "3.10.1"
   },
   "devDependencies": {
-    "babel": "5.4.7"
+    "babel": "5.x"
   }
 }


### PR DESCRIPTION
Noticed that babel 5.4.7 actually had a bug with the invocation of `-d`, making the build silently fail. May as well be on the latest (non-6.x) babel version and latest of everything else.
