### PR TITLE
Support union types

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -84,6 +84,10 @@ function toType(anno:TypeAnnotation):Type {
     return literalType((anno : any))
   }
 
+  else if (anno.type === Syntax.UnionTypeAnnotation) {
+    return unionType((anno : any))
+  }
+
   else {
     return valueType(anno)
   }
@@ -118,6 +122,12 @@ function literalType(anno:StringLiteralTypeAnnotation):Type {
   return type
 }
 
+function unionType(anno:UnionTypeAnnotation):Type {
+  var type = (emptyType('Union') : any)
+  type.types = anno.types.map(toType)
+  return type
+}
+
 //VoidTypeAnnotation
 //StringTypeAnnotation
 //BooleanTypeAnnotation
@@ -125,11 +135,11 @@ function literalType(anno:StringLiteralTypeAnnotation):Type {
 //FunctionTypeAnnotation
 //StringLiteralTypeAnnotation
 //AnyTypeAnnotation
+//UnionTypeAnnotation
 
 // UNSUPPORTED
 //ArrayTypeAnnotation (it uses GenericTypeAnnotation)
 //IntersectionTypeAnnotation
-//UnionTypeAnnotation
 //TupleTypeAnnotation
 //TypeAnnotation
 //TypeofTypeAnnotation

--- a/src/parse.js
+++ b/src/parse.js
@@ -267,6 +267,11 @@ type GenericTypeAnnotation = {
   typeParameters: ?TypeParameters;
 }
 
+type UnionTypeAnnotation = {
+  type: "UnionTypeAnnotation";
+  types: TypeAnnotation[];
+}
+
 //////////////////////////////////////////////////////////////////
 
 type SyntaxTokens = {

--- a/src/parse.js
+++ b/src/parse.js
@@ -236,7 +236,7 @@ type Identifier = {
 // annotations
 
 // use an intersection type so I don't have to cast later
-type TypeAnnotation = ObjectTypeAnnotation | ValueTypeAnnotation | GenericTypeAnnotation | WrapperTypeAnnotation | StringLiteralTypeAnnotation;
+type TypeAnnotation = ObjectTypeAnnotation | ValueTypeAnnotation | GenericTypeAnnotation | WrapperTypeAnnotation | StringLiteralTypeAnnotation | UnionTypeAnnotation;
 
 type ValueTypeAnnotation = {
   type: string; // StringTypeAnnotation, NumberTypeAnnotation

--- a/src/types.js
+++ b/src/types.js
@@ -20,4 +20,7 @@ export type Type = {
 
   // only filled for generics, like Array<XX>
   params?: Array<Type>;
+
+  // only filled for union types
+  types?: Array<Type>;
 }


### PR DESCRIPTION
Adds support for union types (just in the `runtime-types` API, not in `validate`)